### PR TITLE
Fixes #57 - Allow for long values in AnalyzedField.Analyze1

### DIFF
--- a/encog-core-cs/App/Analyst/Analyze/AnalyzedField.cs
+++ b/encog-core-cs/App/Analyst/Analyze/AnalyzedField.cs
@@ -140,7 +140,7 @@ namespace Encog.App.Analyst.Analyze
             {
                 try
                 {
-                    int i = Int32.Parse(str);
+                    Int64 i = Int64.Parse(str);
                     Max = Math.Max(i, Max);
                     Min = Math.Min(i, Min);
                     if (!accountedFor)


### PR DESCRIPTION
See #57 for details on preventing OverflowException

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jeroldhaas/encog-dotnet-core/1)

<!-- Reviewable:end -->
